### PR TITLE
feat: implement `skipPaths` option for 'license' policy

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,9 +1,0 @@
-exclude:
-- /vendor/.*
-- /docs/.*
-- /website/.*
-- brigade.js
-component_depth: 1
-languages:
-- go
-- script

--- a/.codebeatignore
+++ b/.codebeatignore
@@ -1,4 +1,0 @@
-docs/**
-vendor/**
-website/**
-brigade.js

--- a/.conform.yaml
+++ b/.conform.yaml
@@ -3,7 +3,7 @@ policies:
   spec:
     headerLength: 89
     dco: true
-    gpg: true
+    gpg: false
     imperative: true
     conventional:
       types:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,63 @@
+kind: pipeline
+name: default
+
+services:
+- name: docker
+  image: docker:dind
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+
+steps:
+  - name: enforce
+    image: autonomy/build-container:latest
+    pull: always
+    commands:
+      - make build
+      - build/conform-linux-amd64 enforce
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+  - name: test
+    image: autonomy/build-container:latest
+    pull: always
+    commands:
+      - make test
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+  - name: image
+    image: autonomy/build-container:latest
+    pull: always
+    commands:
+      - make image
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+  - name: push
+    image: autonomy/build-container:latest
+    pull: always
+    environment:
+      DOCKER_USERNAME:
+        from_secret: docker_username
+      DOCKER_PASSWORD:
+        from_secret: docker_password
+    commands:
+      - make login
+      - make push
+    volumes:
+      - name: dockersock
+        path: /var/run
+    when:
+      branch:
+        - master
+      event:
+        - push
+
+volumes:
+- name: dockersock
+  temp: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ ENV CGO_ENABLED 0
 ENV GO111MODULES on
 
 WORKDIR /conform
-COPY ./ ./
+COPY go.mod ./
+COPY go.sum ./
 RUN go mod download
 RUN go mod verify
-RUN go mod tidy
+COPY ./ ./
+RUN go list -mod=readonly all
 
 FROM common AS build
 ARG TAG

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHA := $(shell gitmeta git sha)
 TAG := $(shell gitmeta image tag)
 BUILT := $(shell gitmeta built)
 
-GOLANG_IMAGE ?= golang:1.11.4
+GOLANG_IMAGE ?= golang:1.12.3
 
 COMMON_ARGS := -f ./Dockerfile --build-arg GOLANG_IMAGE=$(GOLANG_IMAGE) --build-arg SHA=$(SHA) --build-arg TAG=$(TAG) --build-arg BUILT="$(BUILT)" .
 
@@ -19,15 +19,15 @@ build:
 		-t conform/$@:$(TAG) \
 		--target=$@ \
 		$(COMMON_ARGS)
-	@docker run --rm -it -v $(PWD)/build:/build conform/$@:$(TAG) cp /conform-linux-amd64 /build
-	@docker run --rm -it -v $(PWD)/build:/build conform/$@:$(TAG) cp /conform-darwin-amd64 /build
+	@docker run --rm -v $(PWD)/build:/build conform/$@:$(TAG) cp /conform-linux-amd64 /build
+	@docker run --rm -v $(PWD)/build:/build conform/$@:$(TAG) cp /conform-darwin-amd64 /build
 
 test:
 	@docker build \
 		-t conform/$@:$(TAG) \
 		--target=$@ \
 		$(COMMON_ARGS)
-	@docker run --rm -it -v $(PWD)/build:/build conform/$@:$(TAG) cp /coverage.txt /build
+	@docker run --rm -v $(PWD)/build:/build conform/$@:$(TAG) cp /coverage.txt /build
 
 image: build
 	@docker build \
@@ -35,14 +35,18 @@ image: build
 		--target=$@ \
 		$(COMMON_ARGS)
 
+.PHONY: login
+login:
+	@docker login --username $(DOCKER_USERNAME) --password $(DOCKER_PASSWORD)
+
 push: image
 	@docker tag autonomy/conform:$(TAG) autonomy/conform:latest
 	@docker push autonomy/conform:$(TAG)
 	@docker push autonomy/conform:latest
 
 deps:
-	@GO111MODULES=on CGO_ENABLED=0 go get -u github.com/autonomy/gitmeta
-	@GO111MODULES=on CGO_ENABLED=0 go get -u github.com/autonomy/conform
+	@GO111MODULE=on CGO_ENABLED=0 go get -u github.com/autonomy/gitmeta
+	@GO111MODULE=on CGO_ENABLED=0 go get -u github.com/autonomy/conform
 
 clean:
 	go clean -modcache

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ policies:
         - "scope"
 - type: license
   spec:
+    skipPaths:
+    - .git/
+    - .build*/
     includeSuffixes:
     - .ext
     excludeSuffixes:

--- a/hack/golangci-lint.yaml
+++ b/hack/golangci-lint.yaml
@@ -99,6 +99,8 @@ linters:
   disable:
     - gas
     - typecheck
+    - gochecknoglobals
+    - gochecknoinits
   disable-all: false
   fast: false
 

--- a/internal/policy/commit/commit.go
+++ b/internal/policy/commit/commit.go
@@ -84,11 +84,9 @@ func (c *Commit) Compliance(options *policy.Options) (report policy.Report) {
 			return
 		}
 		msg = string(contents)
-	} else {
-		if msg, err = g.Message(); err != nil {
-			report.Errors = append(report.Errors, errors.Errorf("failed to get commit message: %v", err))
-			return
-		}
+	} else if msg, err = g.Message(); err != nil {
+		report.Errors = append(report.Errors, errors.Errorf("failed to get commit message: %v", err))
+		return
 	}
 
 	if c.HeaderLength != 0 {


### PR DESCRIPTION
This allows to skip directories which shouldn't be checked (e.g.
`.git/`) or directories which aren't readable.

While I was at it, bumped Go version, golangci-lint, refactored tests to
avoid duplicated code and make linter happy.

Rearranged a bit `Dockerfile` to avoid `go mod download` when `go.mod`
is not changed.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>