### PR TITLE
feat: support for allow-all scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ policies:
     dco: true
     gpg: true
     imperative: true
+    anyScope: false
     conventional:
       types:
         - "type"

--- a/internal/policy/commit/commit.go
+++ b/internal/policy/commit/commit.go
@@ -27,6 +27,10 @@ type Commit struct {
 	// Imperative enforces the use of imperative verbs as the first word of a
 	// commit message.
 	Imperative bool `mapstructure:"imperative"`
+	// AnyScope allows any scope and ignores Commit.Conventional.Scopes. This
+	// is useful if you have a very large repository with too many scopes than
+	// can be kept track of.
+	AnyScope bool `mapstructure:"anyScope"`
 	// Conventional is the user specified settings for conventional commits.
 	Conventional *Conventional `mapstructure:"conventional"`
 }
@@ -118,7 +122,9 @@ func (c *Commit) Compliance(options *policy.Options) (report policy.Report) {
 		}
 
 		ValidateType(&report, groups, c.Conventional.Types)
-		ValidateScope(&report, groups, c.Conventional.Scopes)
+		if !c.AnyScope {
+			ValidateScope(&report, groups, c.Conventional.Scopes)
+		}
 		ValidateDescription(&report, groups)
 	}
 


### PR DESCRIPTION
We have a very large repository where scope can't be enforced. This
commit makes whitelisted scopes optional.

Side-note: I've always understood (based on [1]) scope to be more of a
free-text field than something whitelisted/enumerated.

[1] https://www.conventionalcommits.org/en/v1.0.0-beta.4/