### PR TITLE
chore: push images for all branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,10 +61,9 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      branch:
-        - master
       event:
-        - push
+        exclude:
+          - pull_request
 
   - name: release
     image: plugins/github-release


### PR DESCRIPTION
This PR enables images to be pushed on a merge, regardless of branch.

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>