### PR TITLE
chore: require a commit body

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -6,6 +6,7 @@ policies:
       gpg: false
       imperative: true
       maximumOfOneCommit: true
+      requireCommitBody: true
       conventional:
         types:
           - chore


### PR DESCRIPTION
This PR enables requireCommitBody, which requires that all commits contain a body.

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>