### PR TITLE
fix: set pass to false if errors in policies

### DIFF
--- a/internal/enforcer/enforcer.go
+++ b/internal/enforcer/enforcer.go
@@ -89,6 +89,7 @@ func (c *Conform) Enforce(setters ...policy.Option) {
 				if err := c.summarizer.SetStatus("failure", p.Type, check.Name(), check.Message()); err != nil {
 					log.Printf("WARNING: summary failed: %+v", err)
 				}
+				pass = false
 			} else {
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t\n", p.Type, check.Name(), "PASS", "<none>")
 				if err := c.summarizer.SetStatus("success", p.Type, check.Name(), check.Message()); err != nil {


### PR DESCRIPTION
This PR sets the `pass` var in the `enforcer` code to `false` if there are errors in the policies.  This allows the command to return exit code 0 on success and exit code 1 on policy failures.

Signed-off-by: Peter Ng <peter@joincivil.com>