### PR TITLE
fix: checks conventional commit format in firstWord

### DIFF
--- a/internal/policy/commit/commit.go
+++ b/internal/policy/commit/commit.go
@@ -104,6 +104,9 @@ func (c Commit) firstWord() (string, error) {
 	var msg string
 	if c.Conventional != nil {
 		groups = parseHeader(c.msg)
+		if len(groups) != 6 {
+			return "", errors.Errorf("Invalid conventional commit format")
+		}
 		msg = groups[4]
 	} else {
 		msg = c.msg


### PR DESCRIPTION
Getting an `index out of range` panic if conventional commits is true and imperative verb is true and the message is not in a conventional commit format.  

This PR checks to ensure we get all the expected groups when the header is parsed. If not, fail as the string should be in a valid conventional commit format before we can figure out the first word for the imperative mood check.