### PR TITLE
feat(policy): Make Conventional commit description configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ policies:
           - "type"
         scopes:
           - "scope"
+        descriptionLength: 72
   - type: license
     spec:
       skipPaths:

--- a/internal/policy/commit/check_conventional_commit.go
+++ b/internal/policy/commit/check_conventional_commit.go
@@ -15,8 +15,9 @@ import (
 // Conventional implements the policy.Policy interface and enforces commit
 // messages to conform the Conventional Commit standard.
 type Conventional struct {
-	Types  []string `mapstructure:"types"`
-	Scopes []string `mapstructure:"scopes"`
+	Types             []string `mapstructure:"types"`
+	Scopes            []string `mapstructure:"scopes"`
+	DescriptionLength int      `mapstructure:"descriptionLength"`
 }
 
 // HeaderRegex is the regular expression used for Conventional Commits
@@ -94,7 +95,11 @@ func (c Commit) ValidateConventionalCommit() policy.Check {
 		}
 	}
 
-	if len(groups[4]) <= 72 && len(groups[4]) != 0 {
+	// Provide a good default value for DescriptionLength
+	if c.Conventional.DescriptionLength == 0 {
+		c.Conventional.DescriptionLength = 72
+	}
+	if len(groups[4]) <= c.Conventional.DescriptionLength && len(groups[4]) != 0 {
 		return check
 	}
 	check.errors = append(check.errors, errors.Errorf("Invalid description: %s", groups[4]))


### PR DESCRIPTION
The max length for the description in a conventional commit was hardcoded to 72 characters. This change makes it configurable.
When no value is provided in the yaml, a default of 72 is used to keep backwards compatibility.

Signed-off-by: Wouter Dullaert <wouter.dullaert@gmail.com>