### PR TITLE
feat: add compatibility with pre-commit.com

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+---
+# install with `pre-commit install -t commit-msg`
+repos:
+  - repo: https://github.com/talos-systems/conform
+    rev: master
+    hooks:
+      - id: conform
+        stages:
+          - commit-msg

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+---
+- id: conform
+  name: Conform
+  description: Run 'conform enforce' for policy enforcement
+  entry: conform enforce --commit-msg-file
+  language: golang
+  stages: [commit-msg]


### PR DESCRIPTION
pre-commit.com is a hook framework for automatically configuring a
repository to incorporate specified hooks for all developers