### PR TITLE
docs: update README to include pre-commit compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ EOF
 chmod +x .git/hooks/commit-msg
 ```
 
+We also provide a [Pre-Commit](https://pre-commit.com) hook that you can use as follows:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/talos-systems/conform
+    rev: master
+    hooks:
+      - id: conform
+        stages:
+          - commit-msg
+```
+
 ### License
 
 [![license](https://img.shields.io/github/license/talos-systems/conform.svg?style=flat-square)](https://github.com/talos-systems/conform/blob/master/LICENSE)


### PR DESCRIPTION
Since we have official support for pre-commit.com now, the README
indicates how to get this included in compatible projects.