### PR TITLE
feat: add checks for header case and last character

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,10 +1,13 @@
 policies:
   - type: commit
     spec:
-      headerLength: 89
+      header:
+        length: 89
+        imperative: true
+        case: lower
+        invalidLastCharacters: .
       dco: true
       gpg: false
-      imperative: true
       maximumOfOneCommit: true
       requireCommitBody: true
       conventional:

--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ Now, create a file named `.conform.yaml` with the following contents:
 policies:
   - type: commit
     spec:
-      headerLength: 89
+      header:
+        length: 89
+        imperative: true
+        case: lower
+        invalidLastCharacters: .
       dco: true
       gpg: false
-      imperative: true
       maximumOfOneCommit: true
       requireCommitBody: true
       conventional:
@@ -71,14 +74,16 @@ In the same directory, run:
 
 ```bash
 $ conform enforce
-POLICY         CHECK                      STATUS        MESSAGE
-commit         Header Length              PASS          <none>
-commit         DCO                        PASS          <none>
-commit         Imperative Mood            PASS          <none>
-commit         Conventional Commit        PASS          <none>
-commit         Number of Commits          PASS          <none>
-commit         Commit Body                PASS          <none>
-license        File Header                PASS          <none>
+POLICY         CHECK                        STATUS        MESSAGE
+commit         Header Length                PASS          <none>
+commit         Imperative Mood              PASS          <none>
+commit         Header Case                  PASS          <none>
+commit         Header Last Character        PASS          <none>
+commit         DCO                          PASS          <none>
+commit         Conventional Commit          PASS          <none>
+commit         Number of Commits            PASS          <none>
+commit         Commit Body                  PASS          <none>
+license        File Header                  PASS          <none>
 ```
 
 To setup a `commit-msg` hook:

--- a/internal/policy/commit/check_body.go
+++ b/internal/policy/commit/check_body.go
@@ -43,10 +43,6 @@ func (h Body) Errors() []error {
 func (c Commit) ValidateBody() policy.Check {
 	check := &Body{}
 
-	if c.HeaderLength != 0 {
-		MaxNumberOfCommitCharacters = c.HeaderLength
-	}
-
 	lines := strings.Split(strings.TrimPrefix(c.msg, "\n"), "\n")
 	valid := false
 	for _, line := range lines[1:] {

--- a/internal/policy/commit/check_header_case.go
+++ b/internal/policy/commit/check_header_case.go
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package commit
+
+import (
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/pkg/errors"
+	"github.com/talos-systems/conform/internal/policy"
+)
+
+// HeaderCaseCheck enforces the case of the first word in the header.
+type HeaderCaseCheck struct {
+	headerCase string
+	errors     []error
+}
+
+// Name returns the name of the check.
+func (h HeaderCaseCheck) Name() string {
+	return "Header Case"
+}
+
+// Message returns to check message.
+func (h HeaderCaseCheck) Message() string {
+	if len(h.errors) != 0 {
+		return h.errors[0].Error()
+	}
+	return "Header case is valid"
+}
+
+// Errors returns any violations of the check.
+func (h HeaderCaseCheck) Errors() []error {
+	return h.errors
+}
+
+// ValidateHeaderCase checks the header length.
+func (c Commit) ValidateHeaderCase() policy.Check {
+	check := &HeaderCaseCheck{headerCase: c.Header.Case}
+
+	firstWord, err := c.firstWord()
+	if err != nil {
+		check.errors = append(check.errors, err)
+		return check
+	}
+
+	first, _ := utf8.DecodeRuneInString(firstWord)
+	if first == utf8.RuneError {
+		check.errors = append(check.errors, errors.New("Header does not start with valid UTF-8 text"))
+		return check
+	}
+
+	var valid bool
+	switch c.Header.Case {
+	case "upper":
+		valid = unicode.IsUpper(first)
+	case "lower":
+		valid = unicode.IsLower(first)
+	default:
+		check.errors = append(check.errors, errors.Errorf("Invalid configured case %s", c.Header.Case))
+		return check
+	}
+	if !valid {
+		check.errors = append(check.errors, errors.Errorf("Commit header case is not %s", c.Header.Case))
+	}
+	return check
+}

--- a/internal/policy/commit/check_header_last_character.go
+++ b/internal/policy/commit/check_header_last_character.go
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package commit
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/pkg/errors"
+	"github.com/talos-systems/conform/internal/policy"
+)
+
+// HeaderLastCharacterCheck enforces that the last character of the header isn't in some set.
+type HeaderLastCharacterCheck struct {
+	errors []error
+}
+
+// Name returns the name of the check.
+func (h HeaderLastCharacterCheck) Name() string {
+	return "Header Last Character"
+}
+
+// Message returns to check message.
+func (h HeaderLastCharacterCheck) Message() string {
+	if len(h.errors) != 0 {
+		return h.errors[0].Error()
+	}
+	return "Header last character is valid"
+}
+
+// Errors returns any violations of the check.
+func (h HeaderLastCharacterCheck) Errors() []error {
+	return h.errors
+}
+
+// ValidateHeaderLastCharacter checks the last character of the header.
+func (c Commit) ValidateHeaderLastCharacter() policy.Check {
+	check := &HeaderLastCharacterCheck{}
+
+	switch last, _ := utf8.DecodeLastRuneInString(c.header()); {
+	case last == utf8.RuneError:
+		check.errors = append(check.errors, errors.New("Header does not end with valid UTF-8 text"))
+	case strings.ContainsRune(c.Header.InvalidLastCharacters, last):
+		check.errors = append(check.errors, errors.Errorf("Commit header ends in %q", last))
+	}
+
+	return check
+}

--- a/internal/policy/commit/check_header_length.go
+++ b/internal/policy/commit/check_header_length.go
@@ -6,7 +6,6 @@ package commit
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/talos-systems/conform/internal/policy"
@@ -42,14 +41,13 @@ func (h HeaderLengthCheck) Errors() []error {
 func (c Commit) ValidateHeaderLength() policy.Check {
 	check := &HeaderLengthCheck{}
 
-	if c.HeaderLength != 0 {
-		MaxNumberOfCommitCharacters = c.HeaderLength
+	if c.Header.Length != 0 {
+		MaxNumberOfCommitCharacters = c.Header.Length
 	}
 
-	header := strings.Split(strings.TrimPrefix(c.msg, "\n"), "\n")[0]
-	check.headerLength = len(header)
+	check.headerLength = len(c.header())
 	if check.headerLength > MaxNumberOfCommitCharacters {
-		check.errors = append(check.errors, errors.Errorf("Commit header is %d characters", len(header)))
+		check.errors = append(check.errors, errors.Errorf("Commit header is %d characters", check.headerLength))
 	}
 
 	return check


### PR DESCRIPTION
I came across this project and loved the overall idea and the imperative check, but I noticed that some other common guidelines (restrictions on the leading case and trailing punctuation of the header) were missing; this adds checks to enforce those. The desired case can be specified as either "upper" or "lower"; the punctuation check is implemented as a general check for disallowing the last character in the header to be from any given set of characters.