### PR TITLE
refactor: rename summarizer to reporter

### DIFF
--- a/cmd/enforce.go
+++ b/cmd/enforce.go
@@ -26,8 +26,8 @@ var enforceCmd = &cobra.Command{
 		// after this point
 		cmd.SilenceUsage = true
 
-		summarizer := cmd.Flags().Lookup("summary").Value.String()
-		e, err := enforcer.New(summarizer)
+		reporter := cmd.Flags().Lookup("reporter").Value.String()
+		e, err := enforcer.New(reporter)
 		if err != nil {
 			return fmt.Errorf("failed to create enforcer: %+v", err)
 		}
@@ -48,6 +48,6 @@ var enforceCmd = &cobra.Command{
 
 func init() {
 	enforceCmd.Flags().String("commit-msg-file", "", "the path to the temporary commit message file")
-	enforceCmd.Flags().String("summary", "none", "the summary method to use")
+	enforceCmd.Flags().String("reporter", "none", "the reporter method to use")
 	rootCmd.AddCommand(enforceCmd)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -81,7 +81,7 @@ var serveCmd = &cobra.Command{
 					log.Printf("failed to write event to disk: %+v\n", err)
 					return
 				}
-				cmd := exec.Command("/proc/self/exe", "enforce", "--summary=github")
+				cmd := exec.Command("/proc/self/exe", "enforce", "--reporter=github")
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stdout
 				cmd.Dir = cloneRepo

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -4,7 +4,7 @@
 
 package policy
 
-// Report summarizes the compliance of a policy.
+// Report reports the compliance of a policy.
 type Report struct {
 	checks []Check
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package summarizer
+package reporter
 
 import (
 	"context"
@@ -20,12 +20,12 @@ import (
 	"github.com/talos-systems/conform/internal/git"
 )
 
-// Summarizer describes a hook for send summarized results to a remote API.
-type Summarizer interface {
+// Reporter describes a hook for sending summarized results to a remote API.
+type Reporter interface {
 	SetStatus(string, string, string, string) error
 }
 
-// GitHub is a summarizer that summarizes policies statuses as GitHub statuses.
+// GitHub is a reporter that summarizes policy statuses as GitHub statuses.
 type GitHub struct {
 	token string
 	owner string
@@ -33,7 +33,7 @@ type GitHub struct {
 	sha   string
 }
 
-// Noop is a summarizer that does nothing.
+// Noop is a reporter that does nothing.
 type Noop struct {
 }
 
@@ -42,9 +42,9 @@ func (n *Noop) SetStatus(state, policy, check, message string) error {
 	return nil
 }
 
-// NewGitHubSummarizer returns a summarizer that posts policy checks as
+// NewGitHubReporter returns a reporter that posts policy checks as
 // status checks on a pull request.
-func NewGitHubSummarizer() (*GitHub, error) {
+func NewGitHubReporter() (*GitHub, error) {
 	token, ok := os.LookupEnv("INPUT_TOKEN")
 	if !ok {
 		return nil, errors.New("missing INPUT_TOKEN")


### PR DESCRIPTION
This changes the nomenclature of the interface for reporting policy
statuses.

BREAKING CHANGE: This renames the `--summary` flag to `--reporter`.