### PR TITLE
chore: fetch refs/heads/master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,9 +11,10 @@ services:
         path: /var/run
 
 steps:
-  - name: git-fetch-tags
+  - name: git-fetch
     image: docker:git
     commands:
+      - git fetch origin +refs/heads/master:refs/heads/master
       - git fetch --tags
 
   - name: build


### PR DESCRIPTION
This fixes a bug that prevented tags from being built.