### PR TITLE
feat: support regex in conventional commit scope

### DIFF
--- a/internal/policy/commit/check_conventional_commit.go
+++ b/internal/policy/commit/check_conventional_commit.go
@@ -84,7 +84,8 @@ func (c Commit) ValidateConventionalCommit() policy.Check {
 	if groups[3] != "" {
 		scopeIsValid := false
 		for _, scope := range c.Conventional.Scopes {
-			if scope == groups[3] {
+			re := regexp.MustCompile(scope)
+			if re.Match([]byte(groups[3])) {
 				scopeIsValid = true
 				break
 			}


### PR DESCRIPTION
This allows for regular expressions to be used in the scope of a
conventional commit.