### PR TITLE
fix: change "jiraKeys" to "keys"

### DIFF
--- a/internal/policy/commit/commit.go
+++ b/internal/policy/commit/commit.go
@@ -32,7 +32,7 @@ type HeaderChecks struct {
 
 // JiraChecks is the configuration for checks for Jira issues
 type JiraChecks struct {
-	Keys []string `mapstructure:"jiraKeys"`
+	Keys []string `mapstructure:"keys"`
 }
 
 // BodyChecks is the configuration for checks on the body of a commit.


### PR DESCRIPTION
Fixes a type in the field name for Jira keys.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
