### PR TITLE
fix: disallow 0 as valid jira issue id

### DIFF
--- a/internal/policy/commit/check_jira.go
+++ b/internal/policy/commit/check_jira.go
@@ -40,7 +40,7 @@ func (j *JiraCheck) Errors() []error {
 func (c Commit) ValidateJiraCheck() policy.Check {
 	check := &JiraCheck{}
 
-	reg := regexp.MustCompile(`.* \[?(\w+)-\d+\]?.*`)
+	reg := regexp.MustCompile(`.* \[?(\w+)-[1-9]{1}\d*\]?.*`)
 
 	if reg.MatchString(c.msg) {
 		submatch := reg.FindStringSubmatch(c.msg)

--- a/internal/policy/commit/check_jira_test.go
+++ b/internal/policy/commit/check_jira_test.go
@@ -91,6 +91,18 @@ func TestCommit_ValidateJiraCheck(t *testing.T) {
 			want: want{errorCount: 1},
 		},
 		{
+			name: "Invalid jira issue number",
+			fields: fields{
+				Header: &HeaderChecks{
+					Jira: &JiraChecks{
+						Keys: []string{"JIRA", "PROJ"},
+					},
+				},
+				msg: "fix: JIRA-0 valid commit",
+			},
+			want: want{errorCount: 1},
+		},
+		{
 			name: "Valid commit with scope",
 			fields: fields{
 				Header: &HeaderChecks{


### PR DESCRIPTION
This change fixes an issue that would allow JIRA-0 to be a valid Jira issue key. Id within Jira always start at 1, and cannot be prefixed by a any amount of leading 0's.

Fixes #191