### PR TITLE
chore: bump golangci-lint and fix linting issues

### DIFF
--- a/cmd/enforce.go
+++ b/cmd/enforce.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/conform/internal/enforcer"
 	"github.com/talos-systems/conform/internal/policy"
 )
 
-// enforceCmd represents the enforce command
+// enforceCmd represents the enforce command.
 var enforceCmd = &cobra.Command{
 	Use:   "enforce",
 	Short: "",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "conform",
 	Short: "Policy enforcement for your pipelines.",

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -14,25 +14,24 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/google/go-github/github"
-	"github.com/spf13/cobra"
-
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/go-github/github"
+	"github.com/spf13/cobra"
 )
 
 const (
 	path = "/github"
 )
 
-// serveCmd represents the serve command
+// serveCmd represents the serve command.
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := os.MkdirAll("/tmp", 0700); err != nil {
+		if err := os.MkdirAll("/tmp", 0o700); err != nil {
 			log.Fatal(err)
 		}
 
@@ -40,6 +39,7 @@ var serveCmd = &cobra.Command{
 			payload, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				log.Printf("failed to read payload: %+v\n", err)
+
 				return
 			}
 
@@ -47,17 +47,20 @@ var serveCmd = &cobra.Command{
 				dir, err := ioutil.TempDir("/tmp", "conform")
 				if err != nil {
 					log.Printf("failed to create temporary directory: %+v\n", err)
+
 					return
 				}
 				// nolint: errcheck
 				defer os.RemoveAll(dir)
 
-				if err = os.MkdirAll(filepath.Join(dir, "github"), 0700); err != nil {
+				if err = os.MkdirAll(filepath.Join(dir, "github"), 0o700); err != nil {
 					log.Printf("failed to create github directory: %+v\n", err)
+
 					return
 				}
-				if err = os.MkdirAll(filepath.Join(dir, "repo"), 0700); err != nil {
+				if err = os.MkdirAll(filepath.Join(dir, "repo"), 0o700); err != nil {
 					log.Printf("failed to create repo directory: %+v\n", err)
+
 					return
 				}
 
@@ -65,6 +68,7 @@ var serveCmd = &cobra.Command{
 				pullRequestEvent := &github.PullRequestEvent{}
 				if err = json.Unmarshal(payload, pullRequestEvent); err != nil {
 					log.Printf("failed to parse pull_request event: %+v\n", err)
+
 					return
 				}
 
@@ -80,6 +84,7 @@ var serveCmd = &cobra.Command{
 				})
 				if err != nil {
 					log.Printf("failed to clone repo: %+v\n", err)
+
 					return
 				}
 
@@ -98,12 +103,14 @@ var serveCmd = &cobra.Command{
 				})
 				if err != nil {
 					log.Printf("failed to fetch %q: %v", refSpec, err)
+
 					return
 				}
 
 				worktree, err := repo.Worktree()
 				if err != nil {
 					log.Printf("failed to get working tree: %v", err)
+
 					return
 				}
 
@@ -113,13 +120,15 @@ var serveCmd = &cobra.Command{
 
 				if err != nil {
 					log.Printf("failed to checkout %q: %v", ref, err)
+
 					return
 				}
 
 				log.Printf("writing %s to disk", event)
 
-				if err = ioutil.WriteFile(event, payload, 0600); err != nil {
+				if err = ioutil.WriteFile(event, payload, 0o600); err != nil {
 					log.Printf("failed to write event to disk: %+v\n", err)
+
 					return
 				}
 				cmd := exec.Command("/proc/self/exe", "enforce", "--reporter=github", "--commit-ref=refs/heads/"+pullRequestEvent.GetPullRequest().GetBase().GetRef())
@@ -130,11 +139,13 @@ var serveCmd = &cobra.Command{
 				err = cmd.Start()
 				if err != nil {
 					log.Printf("failed to start command: %+v\n", err)
+
 					return
 				}
 				err = cmd.Wait()
 				if err != nil {
 					log.Printf("command failed: %+v\n", err)
+
 					return
 				}
 			}()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/spf13/cobra"
+
 	"github.com/talos-systems/conform/internal/constants"
 )
 
@@ -42,7 +43,7 @@ type Version struct {
 	Arch      string
 }
 
-// versionCmd represents the version command
+// versionCmd represents the version command.
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version",

--- a/hack/golangci-lint.yaml
+++ b/hack/golangci-lint.yaml
@@ -93,6 +93,8 @@ linters-settings:
     simple: true
     range-loops: true # Report preallocation suggestions on range loops, true by default
     for-loops: false # Report preallocation suggestions on for loops, false by default
+  gci:
+    local-prefixes: github.com/talos-systems/conform
 
 linters:
   enable-all: true
@@ -102,8 +104,14 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - funlen
-    - gomnd
+    - godox
     - gocognit
+    - gomnd
+    - goerr113
+    - nestif
+    - exhaustivestruct
+    - errorlint
+    - wrapcheck
   disable-all: false
   fast: false
 

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -7,7 +7,7 @@ CGO_ENABLED=1
 lint_packages() {
   if [ "${lint}" = true ]; then
     echo "linting packages"
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.24.0
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.32.2
     golangci-lint run --config "${BASH_SOURCE%/*}/golangci-lint.yaml"
   fi
 }

--- a/internal/enforcer/enforcer.go
+++ b/internal/enforcer/enforcer.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/talos-systems/conform/internal/policy"
 	"github.com/talos-systems/conform/internal/policy/commit"
 	"github.com/talos-systems/conform/internal/policy/license"
 	"github.com/talos-systems/conform/internal/reporter"
-
-	yaml "gopkg.in/yaml.v2"
 )
 
 // Conform is a struct that conform.yaml gets decoded into.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -172,6 +172,7 @@ func (g *Git) AheadBehind(ref string) (ahead int, behind int, err error) {
 	err = iter.ForEach(func(comm *object.Commit) error {
 		if comm.Hash != ref1.Hash() {
 			count++
+
 			return nil
 		}
 

--- a/internal/policy/commit/check_body.go
+++ b/internal/policy/commit/check_body.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/policy"
 )
 
@@ -54,6 +55,7 @@ func (c Commit) ValidateBody() policy.Check {
 
 		if line != "" {
 			valid = true
+
 			break
 		}
 	}

--- a/internal/policy/commit/check_conventional_commit.go
+++ b/internal/policy/commit/check_conventional_commit.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/policy"
 )
 
@@ -67,6 +68,7 @@ func (c Commit) ValidateConventionalCommit() policy.Check {
 
 	if len(groups) != 6 {
 		check.errors = append(check.errors, errors.Errorf("Invalid conventional commits format: %q", c.msg))
+
 		return check
 	}
 
@@ -81,6 +83,7 @@ func (c Commit) ValidateConventionalCommit() policy.Check {
 
 	if !typeIsValid {
 		check.errors = append(check.errors, errors.Errorf("Invalid type %q: allowed types are %v", groups[1], c.Conventional.Types))
+
 		return check
 	}
 
@@ -92,12 +95,14 @@ func (c Commit) ValidateConventionalCommit() policy.Check {
 			re := regexp.MustCompile(scope)
 			if re.Match([]byte(groups[3])) {
 				scopeIsValid = true
+
 				break
 			}
 		}
 
 		if !scopeIsValid {
 			check.errors = append(check.errors, errors.Errorf("Invalid scope %q: allowed scopes are %v", groups[3], c.Conventional.Scopes))
+
 			return check
 		}
 	}

--- a/internal/policy/commit/check_dco.go
+++ b/internal/policy/commit/check_dco.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/policy"
 )
 

--- a/internal/policy/commit/check_gpg_signature.go
+++ b/internal/policy/commit/check_gpg_signature.go
@@ -6,6 +6,7 @@ package commit
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/git"
 	"github.com/talos-systems/conform/internal/policy"
 )
@@ -41,6 +42,7 @@ func (c Commit) ValidateGPGSign(g *git.Git) policy.Check {
 	ok, err := g.HasGPGSignature()
 	if err != nil {
 		check.errors = append(check.errors, err)
+
 		return check
 	}
 

--- a/internal/policy/commit/check_header_case.go
+++ b/internal/policy/commit/check_header_case.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/policy"
 )
 
@@ -44,12 +45,14 @@ func (c Commit) ValidateHeaderCase() policy.Check {
 	firstWord, err := c.firstWord()
 	if err != nil {
 		check.errors = append(check.errors, err)
+
 		return check
 	}
 
 	first, _ := utf8.DecodeRuneInString(firstWord)
 	if first == utf8.RuneError {
 		check.errors = append(check.errors, errors.New("Header does not start with valid UTF-8 text"))
+
 		return check
 	}
 
@@ -62,6 +65,7 @@ func (c Commit) ValidateHeaderCase() policy.Check {
 		valid = unicode.IsLower(first)
 	default:
 		check.errors = append(check.errors, errors.Errorf("Invalid configured case %s", c.Header.Case))
+
 		return check
 	}
 

--- a/internal/policy/commit/check_header_last_character.go
+++ b/internal/policy/commit/check_header_last_character.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/policy"
 )
 

--- a/internal/policy/commit/check_header_length.go
+++ b/internal/policy/commit/check_header_length.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/policy"
 )
 

--- a/internal/policy/commit/check_imperative_verb.go
+++ b/internal/policy/commit/check_imperative_verb.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/talos-systems/conform/internal/policy"
 	"gopkg.in/jdkato/prose.v2"
+
+	"github.com/talos-systems/conform/internal/policy"
 )
 
 // ImperativeCheck enforces that the first word of a commit message header is
@@ -48,17 +49,20 @@ func (c Commit) ValidateImperative() policy.Check {
 
 	if word, err = c.firstWord(); err != nil {
 		check.errors = append(check.errors, err)
+
 		return check
 	}
 
 	doc, err := prose.NewDocument("I " + strings.ToLower(word))
 	if err != nil {
 		check.errors = append(check.errors, errors.Errorf("Failed to create document: %v", err))
+
 		return check
 	}
 
 	if len(doc.Tokens()) != 2 {
 		check.errors = append(check.errors, errors.Errorf("Expected 2 tokens, got %d", len(doc.Tokens())))
+
 		return check
 	}
 

--- a/internal/policy/commit/check_jira.go
+++ b/internal/policy/commit/check_jira.go
@@ -8,10 +8,11 @@ import (
 	"regexp"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/policy"
 )
 
-// JiraCheck enforces that a Jira issue is mentioned in the header
+// JiraCheck enforces that a Jira issue is mentioned in the header.
 type JiraCheck struct {
 	errors []error
 }
@@ -35,7 +36,7 @@ func (j *JiraCheck) Errors() []error {
 	return j.errors
 }
 
-// ValidateJiraCheck validates if a Jira issue is mentioned in the header
+// ValidateJiraCheck validates if a Jira issue is mentioned in the header.
 func (c Commit) ValidateJiraCheck() policy.Check {
 	check := &JiraCheck{}
 

--- a/internal/policy/commit/check_jira_test.go
+++ b/internal/policy/commit/check_jira_test.go
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// nolint: testpackage
 package commit
 
 import (

--- a/internal/policy/commit/check_number_of_commits.go
+++ b/internal/policy/commit/check_number_of_commits.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/git"
 	"github.com/talos-systems/conform/internal/policy"
 )
@@ -50,11 +51,13 @@ func (c Commit) ValidateNumberOfCommits(g *git.Git, ref string) policy.Check {
 
 	if err != nil {
 		check.errors = append(check.errors, err)
+
 		return check
 	}
 
 	if check.ahead > 1 {
 		check.errors = append(check.errors, errors.Errorf("HEAD is %d commit(s) ahead of %s", check.ahead, ref))
+
 		return check
 	}
 

--- a/internal/policy/commit/check_spelling.go
+++ b/internal/policy/commit/check_spelling.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/talos-systems/conform/internal/policy"
-
 	"github.com/golangci/misspell"
+
+	"github.com/talos-systems/conform/internal/policy"
 )
 
 // SpellCheck represents to spell check policy.

--- a/internal/policy/commit/commit.go
+++ b/internal/policy/commit/commit.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/talos-systems/conform/internal/git"
 	"github.com/talos-systems/conform/internal/policy"
 )
@@ -30,7 +31,7 @@ type HeaderChecks struct {
 	Jira *JiraChecks `mapstructure:"jira"`
 }
 
-// JiraChecks is the configuration for checks for Jira issues
+// JiraChecks is the configuration for checks for Jira issues.
 type JiraChecks struct {
 	Keys []string `mapstructure:"keys"`
 }

--- a/internal/policy/commit/commit_test.go
+++ b/internal/policy/commit/commit_test.go
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// nolint: testpackage
 package commit
 
 import (

--- a/internal/policy/license/license.go
+++ b/internal/policy/license/license.go
@@ -88,6 +88,7 @@ func (l License) ValidateLicenseHeader() policy.Check {
 
 	if l.Header == "" {
 		check.errors = append(check.errors, errors.New("Header is not defined"))
+
 		return check
 	}
 
@@ -123,6 +124,7 @@ func (l License) ValidateLicenseHeader() policy.Check {
 					var contents []byte
 					if contents, err = ioutil.ReadFile(path); err != nil {
 						check.errors = append(check.errors, errors.Errorf("Failed to open %s", path))
+
 						return nil
 					}
 
@@ -134,9 +136,9 @@ func (l License) ValidateLicenseHeader() policy.Check {
 				}
 			}
 		}
+
 		return nil
 	})
-
 	if err != nil {
 		check.errors = append(check.errors, errors.Errorf("Failed to walk directory: %v", err))
 	}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
+
 	"github.com/talos-systems/conform/internal/git"
 )
 
@@ -97,6 +98,7 @@ func NewGitHubReporter() (*GitHub, error) {
 
 // SetStatus sets the status of a GitHub check.
 // Valid statuses are "error", "failure", "pending", "success"
+// nolint: godot
 func (gh *GitHub) SetStatus(state, policy, check, message string) error {
 	if gh.token == "" {
 		return errors.New("no token")


### PR DESCRIPTION
chore: bump golangci-lint and fix linting issues

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

Note:
Copied `linter.disable` array and `golangci-lint` version from `talos` repository.