### PR TITLE
fix: change check_jira regexp

### DIFF
--- a/internal/policy/commit/check_jira.go
+++ b/internal/policy/commit/check_jira.go
@@ -40,7 +40,7 @@ func (j *JiraCheck) Errors() []error {
 func (c Commit) ValidateJiraCheck() policy.Check {
 	check := &JiraCheck{}
 
-	reg := regexp.MustCompile(`.* \[?(\w+)-[1-9]{1}\d*\]?.*`)
+	reg := regexp.MustCompile(`.* \[?([A-Z]*)-[1-9]{1}\d*\]?.*`)
 
 	if reg.MatchString(c.msg) {
 		submatch := reg.FindStringSubmatch(c.msg)


### PR DESCRIPTION
By default, JIra project key must be at least 2 characters long and contain only uppercase letters.
https://confluence.atlassian.com/adminjiraserver/editing-a-project-key-938847080.html 

Fixes #197 

Signed-off-by: Anton Isakov <anton.isakov@dowjones.com>