### PR TITLE
Add Conventional Commit breaking change support

### DIFF
--- a/internal/policy/commit/commit_test.go
+++ b/internal/policy/commit/commit_test.go
@@ -36,6 +36,16 @@ func TestConventionalCommitPolicy(t *testing.T) {
 			ExpectValid:  true,
 		},
 		{
+			Name:         "Breaking",
+			CreateCommit: createBreakingCommit,
+			ExpectValid:  true,
+		},
+		{
+			Name:         "InvalidBreaking",
+			CreateCommit: createInvalidBreakingCommit,
+			ExpectValid:  false,
+		},
+		{
 			Name:         "Invalid",
 			CreateCommit: createInvalidCommit,
 			ExpectValid:  false,
@@ -328,6 +338,18 @@ func initRepo() error {
 
 func createValidCommit() error {
 	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "-m", "type(scope): description").Output()
+
+	return err
+}
+
+func createBreakingCommit() error {
+	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "-m", "feat!: description").Output()
+
+	return err
+}
+
+func createInvalidBreakingCommit() error {
+	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "-m", "feat$: description").Output()
 
 	return err
 }


### PR DESCRIPTION
## Description
Conventional Commit standard allows for "!" immediately following type
and preceding scope to indicate a breaking change. Conform fails against
this commit style, so this change allows such commit messages to pass
policy check.

Signed-off-by: Joey Espinosa <jlouis.espinosa@gmail.com>
