### PR TITLE
fix: update number of regex groups in internal/policy/commit/commit.go

### DIFF
--- a/internal/policy/commit/commit.go
+++ b/internal/policy/commit/commit.go
@@ -158,11 +158,11 @@ func (c Commit) firstWord() (string, error) {
 
 	if c.Conventional != nil {
 		groups = parseHeader(c.msg)
-		if len(groups) != 6 {
+		if len(groups) != 7 {
 			return "", errors.Errorf("Invalid conventional commit format")
 		}
 
-		msg = groups[4]
+		msg = groups[5]
 	} else {
 		msg = c.msg
 	}


### PR DESCRIPTION
Commit c23e2fc added "!" for breaking change support to the HeaderRegex
in internal/policy/commit/check_conventional_commit.go but did not
update the number of regex match groups in
internal/policy/commit/commit.go. This change updates the number of
groups from 6 to 7 in this file.