### PR TITLE
feat: allow comments before the license header

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -33,6 +33,7 @@ policies:
     excludeSuffixes:
       - .pb.go
       - .pb.gw.go
+    allowPrecedingComments: true
     header: |
       // This Source Code Form is subject to the terms of the Mozilla Public
       // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ policies:
         - .ext
       excludeSuffixes:
         - .exclude-ext-prefix.ext
+      allowPrecedingComments: false
       header: |
         This is the contents of a license header.
 ```

--- a/cmd/conform/serve.go
+++ b/cmd/conform/serve.go
@@ -50,8 +50,8 @@ var serveCmd = &cobra.Command{
 
 					return
 				}
-				//nolint: errcheck
-				defer os.RemoveAll(dir)
+
+				defer os.RemoveAll(dir) //nolint:errcheck
 
 				if err = os.MkdirAll(filepath.Join(dir, "github"), 0o700); err != nil {
 					log.Printf("failed to create github directory: %+v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/talos-systems/conform
 
+go 1.13
+
 require (
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
@@ -18,11 +20,10 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gonum.org/v1/gonum v0.6.1 // indirect
 	gopkg.in/jdkato/prose.v2 v2.0.0-20180825173540-767a23049b9e
 	gopkg.in/neurosnap/sentences.v1 v1.0.6 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )
-
-go 1.13

--- a/internal/enforcer/enforcer.go
+++ b/internal/enforcer/enforcer.go
@@ -112,8 +112,7 @@ func (c *Conform) Enforce(setters ...policy.Option) error {
 		}
 	}
 
-	//nolint: errcheck
-	w.Flush()
+	w.Flush() //nolint:errcheck
 
 	if !pass {
 		return errors.New("1 or more policy failed")

--- a/internal/policy/commit/check_jira_test.go
+++ b/internal/policy/commit/check_jira_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint: testpackage
+//nolint:testpackage
 package commit
 
 import (

--- a/internal/policy/commit/commit_test.go
+++ b/internal/policy/commit/commit_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint: testpackage
+//nolint:testpackage
 package commit
 
 import (

--- a/internal/policy/license/license_test.go
+++ b/internal/policy/license/license_test.go
@@ -1,0 +1,43 @@
+//go:build !some_test_tag
+// +build !some_test_tag
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package license_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/conform/internal/policy/license"
+)
+
+func TestLicense(t *testing.T) {
+	const header = `
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.`
+
+	t.Run("Default", func(t *testing.T) {
+		l := license.License{
+			IncludeSuffixes:        []string{".go"},
+			AllowPrecedingComments: false,
+			Header:                 header,
+		}
+		check := l.ValidateLicenseHeader()
+		assert.Equal(t, "Found 1 files without license header", check.Message())
+	})
+
+	t.Run("AllowPrecedingComments", func(t *testing.T) {
+		l := license.License{
+			IncludeSuffixes:        []string{".go"},
+			AllowPrecedingComments: true,
+			Header:                 header,
+		}
+		check := l.ValidateLicenseHeader()
+		assert.Equal(t, "All files have a valid license header", check.Message())
+	})
+}


### PR DESCRIPTION
Useful for controller-gen and other code generators.

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@talos-systems.com>