### PR TITLE
fix: update jira issue valid message

### DIFF
--- a/internal/policy/commit/check_jira.go
+++ b/internal/policy/commit/check_jira.go
@@ -28,7 +28,7 @@ func (j *JiraCheck) Message() string {
 		return j.errors[0].Error()
 	}
 
-	return "Jira issues are invalid"
+	return "Jira issues are valid"
 }
 
 // Errors returns any violations of the check.


### PR DESCRIPTION
Currently when the Jira issue check passes it responds with `Jira issues are invalid`. This updates the check to return the expected message.