### PR TITLE
fix: checkout a branch only once

### DIFF
--- a/cmd/conform/serve.go
+++ b/cmd/conform/serve.go
@@ -79,6 +79,7 @@ var serveCmd = &cobra.Command{
 
 				repo, err := git.PlainClone(cloneRepo, false, &git.CloneOptions{
 					SingleBranch: false,
+					NoCheckout:   true,
 					URL:          cloneURL,
 					Progress:     os.Stdout,
 				})


### PR DESCRIPTION
This is the 2nd attempt to fix checkout with symlinks via go-git.

The first `clone` action was checking out `master` branch, and then
switching to the PR branch. This causes issues wigh `go-git`, and we
don't need to checkout `master` branch for real.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>