### PR TITLE
fix: field order for breaking conventional commit

### DIFF
--- a/internal/policy/commit/check_conventional_commit.go
+++ b/internal/policy/commit/check_conventional_commit.go
@@ -21,9 +21,8 @@ type Conventional struct {
 	DescriptionLength int      `mapstructure:"descriptionLength"`
 }
 
-// HeaderRegex is the regular expression used for Conventional Commits
-// 1.0.0-beta.1.
-var HeaderRegex = regexp.MustCompile(`^(\w*)(\!)?(\(([^)]+)\))?:\s{1}(.*)($|\n{2})`)
+// HeaderRegex is the regular expression used for Conventional Commits 1.0.0.
+var HeaderRegex = regexp.MustCompile(`^(\w*)(\(([^)]+)\))?(!)?:\s{1}(.*)($|\n{2})`)
 
 const (
 	// TypeFeat is a commit of the type fix patches a bug in your codebase
@@ -73,7 +72,7 @@ func (c Commit) ValidateConventionalCommit() policy.Check {
 
 	// conventional commit sections
 	ccType := groups[1]
-	ccScope := groups[4]
+	ccScope := groups[3]
 	ccDesc := groups[5]
 
 	c.Conventional.Types = append(c.Conventional.Types, TypeFeat, TypeFix)

--- a/internal/policy/commit/commit_test.go
+++ b/internal/policy/commit/commit_test.go
@@ -33,17 +33,27 @@ func TestConventionalCommitPolicy(t *testing.T) {
 	for _, test := range []testDesc{
 		{
 			Name:         "Valid",
-			CreateCommit: createValidCommit,
+			CreateCommit: createValidScopedCommit,
 			ExpectValid:  true,
 		},
 		{
-			Name:         "Breaking",
-			CreateCommit: createBreakingCommit,
+			Name:         "ValidBreaking",
+			CreateCommit: createValidBreakingCommit,
 			ExpectValid:  true,
 		},
 		{
-			Name:         "InvalidBreaking",
-			CreateCommit: createInvalidBreakingCommit,
+			Name:         "InvalidBreakingSymbol",
+			CreateCommit: createInvalidBreakingSymbolCommit,
+			ExpectValid:  false,
+		},
+		{
+			Name:         "ValidScopedBreaking",
+			CreateCommit: createValidScopedBreakingCommit,
+			ExpectValid:  true,
+		},
+		{
+			Name:         "InvalidScopedBreaking",
+			CreateCommit: createInvalidScopedBreakingCommit,
 			ExpectValid:  false,
 		},
 		{
@@ -52,8 +62,8 @@ func TestConventionalCommitPolicy(t *testing.T) {
 			ExpectValid:  false,
 		},
 		{
-			Name:         "Empty",
-			CreateCommit: createEmptyCommit,
+			Name:         "InvalidEmpty",
+			CreateCommit: createInvalidEmptyCommit,
 			ExpectValid:  false,
 		},
 	} {
@@ -158,7 +168,7 @@ func TestValidConventionalCommitPolicy(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = createValidCommit()
+	err = createValidScopedCommit()
 	if err != nil {
 		t.Error(err)
 	}
@@ -224,7 +234,7 @@ func TestEmptyConventionalCommitPolicy(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = createEmptyCommit()
+	err = createInvalidEmptyCommit()
 	if err != nil {
 		t.Error(err)
 	}
@@ -332,20 +342,32 @@ func initRepo() error {
 	return err
 }
 
-func createValidCommit() error {
+func createValidScopedCommit() error {
 	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "-m", "type(scope): description").Output()
 
 	return err
 }
 
-func createBreakingCommit() error {
+func createValidBreakingCommit() error {
 	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "-m", "feat!: description").Output()
 
 	return err
 }
 
-func createInvalidBreakingCommit() error {
+func createInvalidBreakingSymbolCommit() error {
 	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "-m", "feat$: description").Output()
+
+	return err
+}
+
+func createValidScopedBreakingCommit() error {
+	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "-m", "feat(scope)!: description").Output()
+
+	return err
+}
+
+func createInvalidScopedBreakingCommit() error {
+	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "-m", "feat!(scope): description").Output()
 
 	return err
 }
@@ -356,7 +378,7 @@ func createInvalidCommit() error {
 	return err
 }
 
-func createEmptyCommit() error {
+func createInvalidEmptyCommit() error {
 	_, err := exec.Command("git", "-c", "user.name='test'", "-c", "user.email='test@talos-systems.io'", "commit", "--allow-empty-message", "-m", "").Output()
 
 	return err


### PR DESCRIPTION
The `!` goes after the scope, not before.

This also updates the Conventional Commits version in comments.
This also standardizes some test/function names.

This is a followup to https://github.com/talos-systems/conform/pull/203.
