### PR TITLE
fix: create a temp dir on hook requests, not a file

### DIFF
--- a/cmd/conform/serve.go
+++ b/cmd/conform/serve.go
@@ -44,27 +44,27 @@ var serveCmd = &cobra.Command{
 			}
 
 			go func() {
-				dir, err := os.CreateTemp("/tmp", "conform")
+				dir, err := os.MkdirTemp("", "conform")
 				if err != nil {
 					log.Printf("failed to create temporary directory: %+v\n", err)
 
 					return
 				}
 
-				defer os.RemoveAll(dir.Name()) //nolint:errcheck
+				defer os.RemoveAll(dir) //nolint:errcheck
 
-				if err = os.MkdirAll(filepath.Join(dir.Name(), "github"), 0o700); err != nil {
+				if err = os.MkdirAll(filepath.Join(dir, "github"), 0o700); err != nil {
 					log.Printf("failed to create github directory: %+v\n", err)
 
 					return
 				}
-				if err = os.MkdirAll(filepath.Join(dir.Name(), "repo"), 0o700); err != nil {
+				if err = os.MkdirAll(filepath.Join(dir, "repo"), 0o700); err != nil {
 					log.Printf("failed to create repo directory: %+v\n", err)
 
 					return
 				}
 
-				event := filepath.Join(dir.Name(), "github", "event.json")
+				event := filepath.Join(dir, "github", "event.json")
 				pullRequestEvent := &github.PullRequestEvent{}
 				if err = json.Unmarshal(payload, pullRequestEvent); err != nil {
 					log.Printf("failed to parse pull_request event: %+v\n", err)
@@ -72,7 +72,7 @@ var serveCmd = &cobra.Command{
 					return
 				}
 
-				cloneRepo := filepath.Join(dir.Name(), "repo")
+				cloneRepo := filepath.Join(dir, "repo")
 				cloneURL := pullRequestEvent.GetPullRequest().GetBase().GetRepo().GetCloneURL()
 
 				log.Printf("Cloning %s", cloneURL)


### PR DESCRIPTION
This was migrated from the deprecated `ioutil.TempDir` in a wrong way, so it was attempting to create a temp file instead of a directory. Was never deployed, so went unnoticed.