### PR TITLE
feat: support checking GPG signature for ranges

### DIFF
--- a/internal/policy/commit/check_gpg_identity.go
+++ b/internal/policy/commit/check_gpg_identity.go
@@ -73,7 +73,7 @@ func (c Commit) ValidateGPGIdentity(g *git.Git) policy.Check { //nolint:ireturn
 			return check
 		}
 
-		entity, err := g.VerifyPGPSignature(keyrings)
+		entity, err := g.VerifyPGPSignature(c.sha, keyrings)
 		if err != nil {
 			check.errors = append(check.errors, err)
 

--- a/internal/policy/commit/check_gpg_signature.go
+++ b/internal/policy/commit/check_gpg_signature.go
@@ -39,7 +39,7 @@ func (g GPGCheck) Errors() []error {
 func (c Commit) ValidateGPGSign(g *git.Git) policy.Check { //nolint:ireturn
 	check := &GPGCheck{}
 
-	ok, err := g.HasGPGSignature()
+	ok, err := g.HasGPGSignature(c.sha)
 	if err != nil {
 		check.errors = append(check.errors, err)
 


### PR DESCRIPTION
The previous implementation always looked at the latest commit (HEAD). This adds the extra metadata of commit SHA in order to use this in the GPG signature check.