### PR TITLE
feat: add custom config file path flag

### DIFF
--- a/cmd/conform/enforce.go
+++ b/cmd/conform/enforce.go
@@ -28,8 +28,12 @@ var enforceCmd = &cobra.Command{
 		// after this point
 		cmd.SilenceUsage = true
 
+		// Get the reporter value
 		reporter := cmd.Flags().Lookup("reporter").Value.String()
-		e, err := enforcer.New(reporter)
+
+		// Get the config path value
+		configPath := cmd.Flags().Lookup("config").Value.String()
+		e, err := enforcer.New(configPath, reporter)
 		if err != nil {
 			return fmt.Errorf("failed to create enforcer: %w", err)
 		}
@@ -68,6 +72,7 @@ func init() {
 	enforceCmd.Flags().String("reporter", "none", "the reporter method to use")
 	enforceCmd.Flags().String("revision-range", "", "<commit1>..<commit2>")
 	enforceCmd.Flags().String("base-branch", "", "base branch to compare with")
+	enforceCmd.Flags().String("config", ".conform.yaml", "config file path")
 	rootCmd.AddCommand(enforceCmd)
 }
 

--- a/internal/enforcer/enforcer.go
+++ b/internal/enforcer/enforcer.go
@@ -39,7 +39,7 @@ type PolicyDeclaration struct {
 }
 
 // New loads the conform.yaml file and unmarshals it into a Conform struct.
-func New(r string) (*Conform, error) {
+func New(cp string, r string) (*Conform, error) {
 	c := &Conform{}
 
 	switch r {
@@ -54,7 +54,7 @@ func New(r string) (*Conform, error) {
 		c.reporter = &reporter.Noop{}
 	}
 
-	configBytes, err := os.ReadFile(".conform.yaml")
+	configBytes, err := os.ReadFile(cp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
What has been done:

Added `--config` flag to enforce command, which let use provide custom config file path.

When not specified, it defaults to `.conform.yaml` in current directory.