### PR TITLE
feat: add format command to fix license headers automatically

### DIFF
--- a/cmd/conform/format.go
+++ b/cmd/conform/format.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siderolabs/conform/internal/enforcer"
+)
+
+// formatCmd represents the format command.
+var formatCmd = &cobra.Command{
+	Use:   "format",
+	Short: "Fix autofixable policy violations",
+	Long:  `Automatically fixes policy violations that can be auto-corrected, such as adding missing license headers.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return errors.New("the format command does not take arguments")
+		}
+		// Done validating the arguments, do not print usage for errors
+		// after this point
+		cmd.SilenceUsage = true
+
+		// Get the config path value
+		configPath := cmd.Flags().Lookup("config").Value.String()
+		e, err := enforcer.New(configPath, "none")
+		if err != nil {
+			return fmt.Errorf("failed to create enforcer: %w", err)
+		}
+
+		diff, err := cmd.Flags().GetBool("diff")
+		if err != nil {
+			return fmt.Errorf("failed to get diff flag: %w", err)
+		}
+
+		return e.Format(diff)
+	},
+}
+
+func init() {
+	formatCmd.Flags().String("config", ".conform.yaml", "config file path")
+	formatCmd.Flags().Bool("diff", false, "show what would change without writing files")
+	rootCmd.AddCommand(formatCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.6.0
@@ -34,7 +35,6 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/internal/policy/fixer.go
+++ b/internal/policy/fixer.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package policy
+
+// FixResult represents the result of fixing a single file.
+//
+//nolint:govet
+type FixResult struct {
+	OldContents []byte
+	NewContents []byte
+	Path        string
+	SkipReason  string
+	Error       error
+	Skipped     bool
+}
+
+// FixReport contains the results of a fix operation.
+type FixReport struct {
+	Results []FixResult
+}
+
+// Fixer is an interface that policies can implement to support auto-fixing violations.
+type Fixer interface {
+	Fix() (*FixReport, error)
+}

--- a/internal/policy/license/license.go
+++ b/internal/policy/license/license.go
@@ -57,7 +57,7 @@ func (l *Licenses) Compliance(_ *policy.Options) (*policy.Report, error) {
 
 // HeaderCheck enforces a license header on source code files.
 type HeaderCheck struct {
-	licenseErrors []error
+	errors []error
 }
 
 // Name returns the name of the check.
@@ -67,8 +67,8 @@ func (l HeaderCheck) Name() string {
 
 // Message returns to check message.
 func (l HeaderCheck) Message() string {
-	if len(l.licenseErrors) != 0 {
-		return fmt.Sprintf("Found %d files without license header", len(l.licenseErrors))
+	if len(l.errors) != 0 {
+		return fmt.Sprintf("Found %d files without license header", len(l.errors))
 	}
 
 	return "All files have a valid license header"
@@ -76,19 +76,19 @@ func (l HeaderCheck) Message() string {
 
 // Errors returns any violations of the check.
 func (l HeaderCheck) Errors() []error {
-	return l.licenseErrors
+	return l.errors
 }
 
 // ValidateLicenseHeaders checks the header of a file and ensures it contains the provided value.
 func (l Licenses) ValidateLicenseHeaders() policy.Check { //nolint:ireturn
-	check := HeaderCheck{}
+	check := &HeaderCheck{}
 
 	for _, license := range l {
 		if license.Root == "" {
 			license.Root = "."
 		}
 
-		check.licenseErrors = append(check.licenseErrors, validateLicenseHeader(license)...)
+		check.errors = append(check.errors, validateLicenseHeader(license)...)
 	}
 
 	return check
@@ -179,38 +179,203 @@ func validateFile(path string, value []byte) error {
 }
 
 func validateFileWithPrecedingComments(path string, value []byte) error {
-	f, err := os.Open(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
-		return errors.Errorf("Failed to open %s: %s", path, err)
-	}
-	defer f.Close() //nolint:errcheck
-
-	var contents []byte
-
-	// read lines until the first non-comment line
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-
-		comment := line == ""
-		comment = comment || strings.HasPrefix(line, "//")
-		comment = comment || strings.HasPrefix(line, "#")
-
-		if !comment {
-			break
-		}
-
-		contents = append(contents, scanner.Bytes()...)
-		contents = append(contents, '\n')
+		return errors.Errorf("Failed to read %s: %s", path, err)
 	}
 
-	if err := scanner.Err(); err != nil {
-		return errors.Errorf("Failed to check file %s: %s", path, err)
-	}
-
-	if bytes.Contains(contents, value) {
+	prefix := extractCommentPrefix(contents)
+	if bytes.Contains(prefix, value) {
 		return nil
 	}
 
 	return errors.Errorf("File %s does not contain a license header", path)
+}
+
+// Fix implements the policy.Fixer interface.
+func (l *Licenses) Fix() (*policy.FixReport, error) {
+	report := &policy.FixReport{}
+
+	for _, license := range *l {
+		if license.Root == "" {
+			license.Root = "."
+		}
+
+		results := fixLicenseHeaders(license)
+		report.Results = append(report.Results, results...)
+	}
+
+	return report, nil
+}
+
+//nolint:gocognit
+func fixLicenseHeaders(license License) []policy.FixResult {
+	var results []policy.FixResult
+
+	var buf bytes.Buffer
+
+	for _, pattern := range license.SkipPaths {
+		fmt.Fprintf(&buf, "%s\n", pattern)
+	}
+
+	patternmatcher := gitignore.New(&buf, license.Root, func(e gitignore.Error) bool {
+		results = append(results, policy.FixResult{
+			Path:  license.Root,
+			Error: e.Underlying(),
+		})
+
+		return true
+	})
+
+	if license.Header == "" {
+		results = append(results, policy.FixResult{
+			Path:  license.Root,
+			Error: errors.New("Header is not defined"),
+		})
+
+		return results
+	}
+
+	header := []byte(strings.TrimSpace(license.Header))
+
+	err := filepath.Walk(license.Root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if patternmatcher.Relative(path, info.IsDir()) != nil {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if info.Mode().IsRegular() {
+			// Skip excluded suffixes.
+			for _, suffix := range license.ExcludeSuffixes {
+				if strings.HasSuffix(info.Name(), suffix) {
+					return nil
+				}
+			}
+
+			// Check files matching the included suffixes.
+			for _, suffix := range license.IncludeSuffixes {
+				if strings.HasSuffix(info.Name(), suffix) {
+					result := fixFile(path, header, license.AllowPrecedingComments)
+					if result.NewContents != nil || result.Skipped || result.Error != nil {
+						results = append(results, result)
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		results = append(results, policy.FixResult{
+			Path:  license.Root,
+			Error: errors.Errorf("Failed to walk directory: %v", err),
+		})
+	}
+
+	return results
+}
+
+func fixFile(path string, header []byte, allowPreceding bool) policy.FixResult {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return policy.FixResult{
+			Path:  path,
+			Error: errors.Errorf("Failed to read %s: %s", path, err),
+		}
+	}
+
+	// Check if the file already has the header
+	if allowPreceding {
+		if fileHasHeaderWithPrecedingComments(contents, header) {
+			return policy.FixResult{Path: path}
+		}
+	} else {
+		if bytes.HasPrefix(contents, header) {
+			return policy.FixResult{Path: path}
+		}
+	}
+
+	// File needs fixing
+	hasShebang, shebangEnd := detectShebang(contents)
+
+	if hasShebang && !allowPreceding {
+		return policy.FixResult{
+			Path:       path,
+			Skipped:    true,
+			SkipReason: "file has shebang but allowPrecedingComments is false",
+		}
+	}
+
+	// Build the new file contents
+	var newContents []byte
+
+	if hasShebang {
+		// Insert header after shebang line
+		newContents = append(newContents, contents[:shebangEnd]...)
+		newContents = append(newContents, header...)
+		newContents = append(newContents, '\n')
+		newContents = append(newContents, contents[shebangEnd:]...)
+	} else {
+		// Insert header at file start
+		newContents = append(newContents, header...)
+		newContents = append(newContents, '\n')
+		newContents = append(newContents, contents...)
+	}
+
+	return policy.FixResult{
+		Path:        path,
+		OldContents: contents,
+		NewContents: newContents,
+	}
+}
+
+func detectShebang(content []byte) (hasShebang bool, endOffset int) {
+	if !bytes.HasPrefix(content, []byte("#!")) {
+		return false, 0
+	}
+
+	// Find the end of the first line
+	idx := bytes.IndexByte(content, '\n')
+	if idx == -1 {
+		// Entire file is the shebang line
+		return true, len(content)
+	}
+
+	return true, idx + 1
+}
+
+// isCommentLine checks if a line (trimmed of whitespace) is a comment or blank line.
+func isCommentLine(line string) bool {
+	return line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "#")
+}
+
+// extractCommentPrefix scans file contents and returns all leading comment lines.
+func extractCommentPrefix(contents []byte) []byte {
+	var prefix []byte
+
+	scanner := bufio.NewScanner(bytes.NewReader(contents))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !isCommentLine(line) {
+			break
+		}
+
+		prefix = append(prefix, scanner.Bytes()...)
+		prefix = append(prefix, '\n')
+	}
+
+	return prefix
+}
+
+func fileHasHeaderWithPrecedingComments(contents []byte, header []byte) bool {
+	prefix := extractCommentPrefix(contents)
+
+	return bytes.Contains(prefix, header)
 }


### PR DESCRIPTION
Adds support for running `conform format` which adds required missing license headers.
This integrates to the policy concept allowing policies to implement a `Fix` method
to create automatic fixes. The license header adding functionality respects shebangs
if preceding comments are allowed in config.
